### PR TITLE
Pop Operations and Boolean operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The > is the "push" operator. It put's what is on it's left on the "stack". The 
 - \+ (append) adds it's argument as a child to the one on the stack. Usually it's adding an item to a group.
 - | (pipe) is a transformation, it changes some attribute of the object on the top of the stack.
 - ~ (tilde) is a conversion. It alters (type casting/converting) the object on the stack, or otherwise significantly changes the object on the stack. It only affects the topmost object.
-
+- . (dot) is a pop operator. Alone, it simply pops. If an identifier follows one or more dots, it will pop 1 or more objects and do something with them. e.g ..subtract or .append
 > If you don't include an operator, but you're on the root of the stack (the base canvas) it will append for convenience. The '+' symbol is always recommended anyway for clarity.
 
 ### Flow Operations

--- a/gram/pmv.ohm.js
+++ b/gram/pmv.ohm.js
@@ -88,21 +88,22 @@ bodyDelim = ("\n" | ";")
   | AppendOperation
   | objectStatement
   
-   MetaStatement =
+  MetaStatement =
   | PushOperation
-  | PopOperation
+  | popOperation
   | FlowOperation
 
 
-PopOperation =
-| (doPop ~whitespace)+ ObjectStatement?
+popOperation =
+| (doPop ~whitespace)+ doAppend
+| (doPop ~whitespace)+ objectStatement?
 
 objectStatement =
 //| ident Object #sc?
 | ident whitespace? listOf<object,whitespace>
     
     PushOperation =
-    (ObjectStatement | AppendOperation | PopOperation) doPush
+    (ObjectStatement | AppendOperation | popOperation) doPush
     AppendOperation =
     doAppend objectStatement
     Transformation

--- a/gram/pmv.ohm.js
+++ b/gram/pmv.ohm.js
@@ -95,7 +95,7 @@ bodyDelim = ("\n" | ";")
 
 
 PopOperation =
-doPop
+| (doPop ~whitespace)+ ObjectStatement?
 
 objectStatement =
 //| ident Object #sc?

--- a/gram/pmv.ohm.js
+++ b/gram/pmv.ohm.js
@@ -102,7 +102,7 @@ objectStatement =
 | ident whitespace? listOf<object,whitespace>
     
     PushOperation =
-    (ObjectStatement | AppendOperation) doPush
+    (ObjectStatement | AppendOperation | PopOperation) doPush
     AppendOperation =
     doAppend objectStatement
     Transformation

--- a/pinch/ast.ts
+++ b/pinch/ast.ts
@@ -91,7 +91,7 @@ class RuntimeNode {
     }
 }
 
-function CreateElementNode(shape: paper.Path){
+function CreateElementNode(shape: paper.Path | paper.PathItem){
     var r = new RuntimeNode();
     r.type = RuntimeType.Element;
     r.elementValue = new RuntimeItem(shape);
@@ -196,7 +196,7 @@ abstract class RuntimeElement {
 class RuntimeItem extends RuntimeElement{
     item: paper.PathItem
 
-    constructor(shape: paper.Path){
+    constructor(shape: paper.Path | paper.PathItem){
         super()
         this.item = shape;
         this.type = RuntimeElementType.Path
@@ -245,4 +245,4 @@ class RuntimeGroup extends RuntimeElement {
     }
 }
 
-export {NodeType, treeNode, Procedure, RuntimeNode, RuntimeType, RuntimeItem, RuntimeGroup, RuntimeElement, CreateElementNode, CreateGroupNode, CreateProcedureNode, CreateNumberNode}
+export {NodeType, treeNode, Procedure, RuntimeNode, RuntimeType, RuntimeItem, RuntimeGroup, RuntimeElement, RuntimeElementType, CreateElementNode, CreateGroupNode, CreateProcedureNode, CreateNumberNode}

--- a/pinch/ast.ts
+++ b/pinch/ast.ts
@@ -1,7 +1,5 @@
 import paper from "paper";
 
-import { collapseTextChangeRangesAcrossMultipleVersions } from "typescript"
-
 enum NodeType {
     Program,
     ObjectStatement,
@@ -195,6 +193,10 @@ abstract class RuntimeElement {
 
 class RuntimeItem extends RuntimeElement{
     item: paper.PathItem
+
+    override AddChild(element: RuntimeElement){
+        throw new Error("addChild is not implemented by runtimeItem.");
+    }
 
     constructor(shape: paper.Path | paper.PathItem){
         super()

--- a/pinch/compiler.ts
+++ b/pinch/compiler.ts
@@ -510,193 +510,21 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
     console.log("pop statement",node.id, args)
     switch(node.id){
         case "subtract":
-            if(args.length == 1){                    
-                let ae = args[0]?.elementValue
-                let be = env.peek().elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.PathItem
-                let b = be.item as paper.PathItem
-                let path = b.subtract(a);
-                
-                be.item = path
-            }else if(args.length == 2){
-                    
-                let ae = args[0]?.elementValue
-                let be = args[1]?.elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.Path
-                let b = be.item as paper.Path
-                let path = b.subtract(a);
-                //new path item, now replace a.
-                //env.peek().elementValue.item = path;
-                env.active = CreateElementNode(path)
-            }else{
-                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
-                throw new Error("Subtract popop must pop 1 (.subtract, modifies top) or 2 (..subtract, creates new) stack arguments")
-            }
-            // a pop operator also pushes back to the stack.
+            doBooleanOp("subtract",args,env);
         break;
         case "intersect":
-            if(args.length == 1){                    
-                let ae = args[0]?.elementValue
-                let be = env.peek().elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.PathItem
-                let b = be.item as paper.PathItem
-                
-                let path = a.intersect(b);
-                
-                be.item = path
-                //env.active = CreateElementNode(path)
-            }else if(args.length == 2){
-                    
-                let ae = args[0]?.elementValue
-                let be = args[1]?.elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.Path
-                let b = be.item as paper.Path
-                let path = a.intersect(b);
-                //new path item, now replace a.
-                //env.peek().elementValue.item = path;
-                env.active = CreateElementNode(path)
-            }else{
-                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
-                throw new Error("Intersect popop must pop 1 (.intersect, modifies top) or 2 (..intersect, creates new) stack arguments")
-            }
-            // a pop operator also pushes back to the stack.
+            doBooleanOp("intersect",args,env);
         break;
         case "exclude":
-            if(args.length == 1){                    
-                let ae = args[0]?.elementValue
-                let be = env.peek().elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.PathItem
-                let b = be.item as paper.PathItem
-                let path = a.exclude(b);
-                
-                be.item = path
-                //env.active = CreateElementNode(path)
-            }else if(args.length == 2){
-                    
-                let ae = args[0]?.elementValue
-                let be = args[1]?.elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.Path
-                let b = be.item as paper.Path
-                let path = a.exclude(b);
-                //new path item, now replace a.
-                //env.peek().elementValue.item = path;
-                env.active = CreateElementNode(path)
-            }else{
-                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
-                throw new Error("Exclude popop must pop 1 (.exc;ude, modifies top) or 2 (..exclude, creates new) stack arguments")
-            }
-            // a pop operator also pushes back to the stack.
+            doBooleanOp("exclude",args,env);
         break;
         case "unite":
-            if(args.length == 1){                    
-                let ae = args[0]?.elementValue
-                let be = env.peek().elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.PathItem
-                let b = be.item as paper.PathItem
-                let path = a.unite(b);
-                
-                be.item = path
-                //env.active = CreateElementNode(path)
-            }else if(args.length == 2){
-                    
-                let ae = args[0]?.elementValue
-                let be = args[1]?.elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.Path
-                let b = be.item as paper.Path
-                let path = a.unite(b);
-                //new path item, now replace a.
-                //env.peek().elementValue.item = path;
-                env.active = CreateElementNode(path)
-            }else{
-                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
-                throw new Error("Unite popop must pop 1 (.unite, modifies top) or 2 (..unite, creates new) stack arguments")
-            }
+            doBooleanOp("unite",args,env);
             // a pop operator also pushes back to the stack.
         break;
         case "divide":
-            if(args.length == 1){                    
-                let ae = args[0]?.elementValue
-                let be = env.peek().elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.PathItem
-                let b = be.item as paper.PathItem
-                let path = b.divide(a);
-                
-                be.item = path
-                //env.active = CreateElementNode(path)
-            }else if(args.length == 2){
-                    
-                let ae = args[0]?.elementValue
-                let be = args[1]?.elementValue
-                if(!ae || !be){
-                    throw new Error("invalid runtime node")
-                }
-                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                    throw new Error("Cannot perform boolean on group (yet)");
-                }
-                let a = ae.item as paper.Path
-                let b = be.item as paper.Path
-                let path = b.divide(a);
-                //new path item, now replace a.
-                //env.peek().elementValue.item = path;
-                env.active = CreateElementNode(path)
-            }else{
-                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
-                throw new Error("Divide popop must pop 1 (.divide, modifies top) or 2 (..divide, creates new) stack arguments")
-            }
+            doBooleanOp("divide",args,env);
+            break;
             // a pop operator also pushes back to the stack.
         break;
         case "append":
@@ -715,6 +543,84 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
         break;
         default:
             throw new Error("Unknown Pop Statement "+node.id)
+    }
+}
+
+function doBooleanOp(op: string, args: RuntimeNode[], env: Environment){
+    let path: paper.PathItem
+    if(args.length == 1){                    
+        let ae = args[0]?.elementValue
+        let be = env.peek().elementValue
+        if(!ae || !be){
+            throw new Error("invalid runtime node")
+        }
+        if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+            throw new Error("Cannot perform boolean on group (yet)");
+        }
+        let a = ae.item as paper.PathItem
+        let b = be.item as paper.PathItem
+        
+        switch(op){
+            case "intersect":
+                path = a.intersect(b);
+            break;
+            case "subtract":
+                path = b.subtract(a);
+            break;
+            case "divide":
+                path = b.divide(a);
+                break;
+            case "unite":
+                path = a.unite(b);
+                break;
+            case "exclude":
+                path = a.exclude(b);
+                break;
+            default:
+                throw new Error("unsupported pop operation "+op);
+        }
+        
+        be.item = path
+        //env.active = CreateElementNode(path)
+    }else if(args.length == 2){
+            
+        let ae = args[0]?.elementValue
+        let be = args[1]?.elementValue
+        if(!ae || !be){
+            throw new Error("invalid runtime node")
+        }
+        if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+            throw new Error("Cannot perform boolean on group (yet)");
+        }
+        let a = ae.item as paper.Path
+        let b = be.item as paper.Path
+        
+        switch(op){
+            case "intersect":
+                path = a.intersect(b);
+            break;
+            case "subtract":
+                path = b.subtract(a);
+            break;
+            case "divide":
+                path = b.divide(a);
+                break;
+            case "unite":
+                path = a.unite(b);
+                break;
+            case "exclude":
+                path = a.exclude(b);
+                break;
+            default:
+                throw new Error("unsupported pop operation "+op);
+        }
+
+        //new path item, now replace a.
+        //env.peek().elementValue.item = path;
+        env.active = CreateElementNode(path)
+    }else{
+        //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
+        throw new Error(op+" boolean popop must pop 1 (."+op+", modifies top) or 2 (.."+op+", creates new) stack arguments")
     }
 }
 

--- a/pinch/compiler.ts
+++ b/pinch/compiler.ts
@@ -90,6 +90,7 @@ function compile(node:treeNode, env: Environment){
                 }else if (c.type == RuntimeType.Element){
                     compile(node.children[0],env);
                     c.appendChildElement(env.active);
+                    console.log(env.active)
                 }
             }else{
                 throw new Error("Cannot Append Nothing")
@@ -398,8 +399,8 @@ function compileStandaloneObjectStatement(node:treeNode, env: Environment){
             if(node.children.length == 1){
                 let content = compile(node.children[0],env)
                 let textitem = new paper.PointText(paper.view.center);
-                // textitem.content = content;
-                // env.active = CreateElementNode(textitem);
+               // textitem.content = content;
+                //env.active = CreateElementNode(textitem);
 
             }else if(node.children.length == 3){
                 let x = parseFloat(compile(node.children[0],env))
@@ -407,8 +408,8 @@ function compileStandaloneObjectStatement(node:treeNode, env: Environment){
                 let content = compile(node.children[2],env)
                 let a = new paper.Point(x,y)
                 let textitem = new paper.PointText(a);
-                // textitem.content = content;
-                // env.active = CreateElementNode(textitem);
+              //  textitem.content = content;
+                //env.active = CreateElementNode(textitem);
             }
             else{
                 throw new Error("Text: bad number of arguments. Want 1 (text) or 3 (x y text)")
@@ -509,7 +510,98 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
     console.log("pop statement",node.id, args)
     switch(node.id){
         case "subtract":
-            if(args.length == 2){
+            if(args.length == 1){                    
+                let ae = args[0]?.elementValue
+                let be = env.peek().elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.PathItem
+                let b = be.item as paper.PathItem
+                let path = b.subtract(a);
+                
+                be.item = path
+            }else if(args.length == 2){
+                    
+                let ae = args[0]?.elementValue
+                let be = args[1]?.elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.Path
+                let b = be.item as paper.Path
+                let path = b.subtract(a);
+                //new path item, now replace a.
+                //env.peek().elementValue.item = path;
+                env.active = CreateElementNode(path)
+            }else{
+                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
+                throw new Error("Subtract popop must pop 1 (.subtract, modifies top) or 2 (..subtract, creates new) stack arguments")
+            }
+            // a pop operator also pushes back to the stack.
+        break;
+        case "intersect":
+            if(args.length == 1){                    
+                let ae = args[0]?.elementValue
+                let be = env.peek().elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.PathItem
+                let b = be.item as paper.PathItem
+                
+                let path = a.intersect(b);
+                
+                be.item = path
+                //env.active = CreateElementNode(path)
+            }else if(args.length == 2){
+                    
+                let ae = args[0]?.elementValue
+                let be = args[1]?.elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.Path
+                let b = be.item as paper.Path
+                let path = a.intersect(b);
+                //new path item, now replace a.
+                //env.peek().elementValue.item = path;
+                env.active = CreateElementNode(path)
+            }else{
+                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
+                throw new Error("Intersect popop must pop 1 (.intersect, modifies top) or 2 (..intersect, creates new) stack arguments")
+            }
+            // a pop operator also pushes back to the stack.
+        break;
+        case "exclude":
+            if(args.length == 1){                    
+                let ae = args[0]?.elementValue
+                let be = env.peek().elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.PathItem
+                let b = be.item as paper.PathItem
+                let path = a.exclude(b);
+                
+                be.item = path
+                //env.active = CreateElementNode(path)
+            }else if(args.length == 2){
                     
                 let ae = args[0]?.elementValue
                 let be = args[1]?.elementValue
@@ -527,7 +619,83 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
                 env.active = CreateElementNode(path)
             }else{
                 //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
-                throw new Error("Subtract popop must have 2 elements e.g:(..subtract)")
+                throw new Error("Exclude popop must pop 1 (.exc;ude, modifies top) or 2 (..exclude, creates new) stack arguments")
+            }
+            // a pop operator also pushes back to the stack.
+        break;
+        case "unite":
+            if(args.length == 1){                    
+                let ae = args[0]?.elementValue
+                let be = env.peek().elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.PathItem
+                let b = be.item as paper.PathItem
+                let path = a.unite(b);
+                
+                be.item = path
+                //env.active = CreateElementNode(path)
+            }else if(args.length == 2){
+                    
+                let ae = args[0]?.elementValue
+                let be = args[1]?.elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.Path
+                let b = be.item as paper.Path
+                let path = a.unite(b);
+                //new path item, now replace a.
+                //env.peek().elementValue.item = path;
+                env.active = CreateElementNode(path)
+            }else{
+                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
+                throw new Error("Unite popop must pop 1 (.unite, modifies top) or 2 (..unite, creates new) stack arguments")
+            }
+            // a pop operator also pushes back to the stack.
+        break;
+        case "divide":
+            if(args.length == 1){                    
+                let ae = args[0]?.elementValue
+                let be = env.peek().elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.PathItem
+                let b = be.item as paper.PathItem
+                let path = b.divide(a);
+                
+                be.item = path
+                //env.active = CreateElementNode(path)
+            }else if(args.length == 2){
+                    
+                let ae = args[0]?.elementValue
+                let be = args[1]?.elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.Path
+                let b = be.item as paper.Path
+                let path = b.divide(a);
+                //new path item, now replace a.
+                //env.peek().elementValue.item = path;
+                env.active = CreateElementNode(path)
+            }else{
+                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
+                throw new Error("Divide popop must pop 1 (.divide, modifies top) or 2 (..divide, creates new) stack arguments")
             }
             // a pop operator also pushes back to the stack.
         break;

--- a/pinch/parser.ts
+++ b/pinch/parser.ts
@@ -49,15 +49,17 @@ s.addOperation("toTree",{
         return new treeNode(NodeType.Flow,op.id,[op,block]);
     },
     //@ts-ignore
-    PopOperation(a){
-        return new treeNode(NodeType.Pop,"pop",[]);
+    PopOperation(a,b){
+        if(b.children.length == 0){
+            return new treeNode(NodeType.Pop,"pop",[a.children.length]);
+        }else{
+            if(b.children[0]){
+            return new treeNode(NodeType.Pop,"pop",[a.children.length, b.children[0].toTree()]);
+            }else{
+                throw new Error("invalid parse somehow");
+            }
+        }
     },
-    
-    //@ts-ignore
-    // StatementBlock(a,b,c){
-    //     let children = b.children.map(x=>x.toTree());
-    //     return new treeNode(NodeType.Block,"{}",children);
-    // },
     //@ts-ignore
     label(a,b){
         return new treeNode(NodeType.Label,b.sourceString,[])

--- a/pinch/parser.ts
+++ b/pinch/parser.ts
@@ -49,12 +49,17 @@ s.addOperation("toTree",{
         return new treeNode(NodeType.Flow,op.id,[op,block]);
     },
     //@ts-ignore
-    PopOperation(a,b){
+    popOperation(a,b){
         if(b.children.length == 0){
             return new treeNode(NodeType.Pop,"pop",[a.children.length]);
         }else{
             if(b.children[0]){
-            return new treeNode(NodeType.Pop,"pop",[a.children.length, b.children[0].toTree()]);
+                if(b.children[0].sourceString === "+"){
+                    //.+ is shorthand for .append
+                    return new treeNode(NodeType.Pop,"pop",[a.children.length, new treeNode(NodeType.Identifier, "append",[])]);
+                }else{
+                    return new treeNode(NodeType.Pop,"pop",[a.children.length, b.children[0].toTree()]);
+                }
             }else{
                 throw new Error("invalid parse somehow");
             }

--- a/pinch/svgGenerator.ts
+++ b/pinch/svgGenerator.ts
@@ -650,23 +650,26 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
     console.log("pop statement",node.id, args)
     switch(node.id){
         case "subtract":
-            if(args.length != 2){
+            if(args.length == 2){
+                    
+                let ae = args[0]?.elementValue
+                let be = args[1]?.elementValue
+                if(!ae || !be){
+                    throw new Error("invalid runtime node")
+                }
+                if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
+                    throw new Error("Cannot perform boolean on group (yet)");
+                }
+                let a = ae.item as paper.Path
+                let b = be.item as paper.Path
+                let path = a.exclude(b);
+                //new path item, now replace a.
+                //env.peek().elementValue.item = path;
+                env.active = CreateElementNode(path)
+            }else{
+                //if we only have one argument, it could modify the prior object, while two will pop both, subtract them, set active.
                 throw new Error("Subtract popop must have 2 elements e.g:(..subtract)")
             }
-            let ae = args[0]?.elementValue
-            let be = args[1]?.elementValue
-            if(!ae || !be){
-                throw new Error("invalid runtime node")
-            }
-            if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
-                throw new Error("Cannot perform boolean on group (yet)");
-            }
-            let a = ae.item as paper.Path
-            let b = be.item as paper.Path
-            let path = a.exclude(b);
-            //new path item, now replace a.
-            //env.peek().elementValue.item = path;
-            env.active = CreateElementNode(path)
             // a pop operator also pushes back to the stack.
         break;
         case "append":

--- a/pinch/svgGenerator.ts
+++ b/pinch/svgGenerator.ts
@@ -656,7 +656,7 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
             let ae = args[0]?.elementValue
             let be = args[1]?.elementValue
             if(!ae || !be){
-                throw new Error("invalid runtime ")
+                throw new Error("invalid runtime node")
             }
             if(ae.type != RuntimeElementType.Path || be.type != RuntimeElementType.Path){
                 throw new Error("Cannot perform boolean on group (yet)");
@@ -667,6 +667,20 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
             //new path item, now replace a.
             //env.peek().elementValue.item = path;
             env.active = CreateElementNode(path)
+            // a pop operator also pushes back to the stack.
+        break;
+        case "append":
+            if(args.length != 1){
+                throw new Error("Append popop must have 2 elements e.g:(.append)")
+            }
+            let appe = args[0]
+            if(!appe){
+                throw new Error("invalid runtime node")
+            }
+            
+            //new path item, now replace a.
+            //env.peek().elementValue.item = path;
+            env.peek().appendChildElement(appe)
             // a pop operator also pushes back to the stack.
         break;
         default:

--- a/pinch/svgGenerator.ts
+++ b/pinch/svgGenerator.ts
@@ -188,10 +188,11 @@ function compileAndRun(canvas: HTMLCanvasElement, root: treeNode){
         compile(child, environment);
     });
 
-    if(environment.stack.length != 1){
-        throw new Error("The stack is "+environment.stack.length+". It should end at 1 (root svg)");
-    }
-    environment.stack.pop();
+    environment.stack.forEach((rt:RuntimeNode)=>{
+        console.log("render stack", rt);
+        rt.elementValue?.Render();
+    });
+    
     environment.root.elementValue?.Render();
 
     return
@@ -662,12 +663,11 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
             }
             let a = ae.item as paper.Path
             let b = be.item as paper.Path
-            let path = a.subtract(b);
+            let path = a.exclude(b);
             //new path item, now replace a.
             //env.peek().elementValue.item = path;
-            env.peek().appendChildElement(CreateElementNode(path))
+            env.active = CreateElementNode(path)
             // a pop operator also pushes back to the stack.
-            //env.push(env.active);
         break;
         default:
             throw new Error("Unknown Pop Statement "+node.id)


### PR DESCRIPTION
Support for pop operations. After a ., an operation can then use the popped item as an argument to modify the existing stack.

```
+ rect 100 >
| dy -100

circle 30 >
.subtract

| fill grey
.
```
*the dy transformer is a different bug on where rects get created*

They can also remove two items and "return" a new item. 

```
rect 100 >
| dy -100
| fill red

circle 30 >
..subtract >

| fill grey
.+
```

Here nothing is appended or anywhere to start, and then after the subtract we push it onto the stack...

and then use the ".+" shorthand for ".append" pop operation.

`circle 10 >.+ `
is the same as 
`+ circle 10 `
although presumably you would push onto the stack (>) do something (|) and then pop-append (.+) instead of just push+pop-append. this way appends can happen at the beginning of an object definition, or at the end -- as they must for booleans.

I think the single . form which modifies the top of the stack is easier and cleaner. May remove .. in the future, but that's the point of this project: figuring things like this out.