### PR TITLE
Stack viz gutter

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,12 @@
            .cm-editor{
             width: 100%;
            }
+
+           .stackBlockGutterItem{
+                width:5px;
+                height: 100%;
+                /* display: inline-block; */
+           }
         </style>
     </head>
 

--- a/interactivePage.ts
+++ b/interactivePage.ts
@@ -106,6 +106,13 @@ const stackViewGutter = gutter({
         let stackdec = []
         for(let i = 0;i<environment.stackMetaItems.length;i++){
           const sm = environment.stackMetaItems[i]
+
+          if(sm?.end===undefined){
+            let end = view.state.doc.lineAt(view.state.doc.length).number
+            //plus 1 so we don't draw end-caps.
+            environment.stackMetaItems[i].end = end+1
+          }
+
           if(!sm){continue}
           if(num === sm.start && num === sm.end){
             stackdec.push("o")
@@ -119,10 +126,6 @@ const stackViewGutter = gutter({
                 }else if(num == sm.end){
                   stackdec.push("/")
                 }
-              }else{
-                //sm.end is undefined
-                stackdec.push("?")
-
               }
             }
           }

--- a/interactivePage.ts
+++ b/interactivePage.ts
@@ -94,37 +94,34 @@ class StackGutterMarker extends GutterMarker {
           let box = document.createElement("span")
           box.classList.add("stackBlockGutterItem")
           //@ts-ignore
-          box.style.backgroundColor = blockColors[i%blockColors.length]
+          box.innerHTML ='<svg  xmlns="http://www.w3.org/2000/svg"  preserveAspectRatio="none" width="100%"  height="100%"  viewBox="0 0 10 10"  fill="'+blockColors[i%blockColors.length]+'"><path stroke="none" d="m0,0 v11 h10 v-11 z"/></svg>';
           box.style.display = "inline-block"
-          box.innerText = " "
           this.innerItem.appendChild(box);
           break;
           case "\\":
             let top = document.createElement("span")
             top.classList.add("stackBlockGutterItem")
             //@ts-ignore
-            top.style.backgroundColor = blockColors[i%blockColors.length]
+            top.innerHTML ='<svg  xmlns="http://www.w3.org/2000/svg"  preserveAspectRatio="none" width="100%"  height="100%"  viewBox="0 0 10 10"  fill="'+blockColors[i%blockColors.length]+'"><path stroke="none" d="m0,0 v11 h11 z"/></svg>';
+            //top.style.backgroundColor = blockColors[i%blockColors.length]
             top.style.display = "inline-block"
-            top.innerText = " "
             this.innerItem.appendChild(top);
             break;
           case "/":
             let bot = document.createElement("span")
             bot.classList.add("stackBlockGutterItem")
             //@ts-ignore
-            bot.style.backgroundColor = blockColors[i%blockColors.length]
+            bot.innerHTML ='<svg  xmlns="http://www.w3.org/2000/svg"  preserveAspectRatio="none" width="100%"  height="100%"  viewBox="0 0 10 10"  fill="'+blockColors[i%blockColors.length]+'"><path d="m0,0 h10 L0,10 z"/></svg>';
+            //top.style.backgroundColor = blockColors[i%blockColors.length]
             bot.style.display = "inline-block"
-            bot.innerText = " "
             this.innerItem.appendChild(bot);
             break;
           case "o":
             let sir = document.createElement("span")
             sir.classList.add("stackBlockGutterItem")
             //@ts-ignore
-            sir.style.backgroundColor = blockColors[i%blockColors.length]
+            sir.innerHTML ='<svg  xmlns="http://www.w3.org/2000/svg"  preserveAspectRatio="none" width="100%"  height="100%"  viewBox="0 0 10 10"  fill="'+blockColors[i%blockColors.length]+'"><path stroke="none" d="m0,0 L10,5 L0,10 z"/></svg>';
             sir.style.display = "inline-block"
-            sir.innerText = " "
-
             this.innerItem.appendChild(sir);
             break;
         default:

--- a/interactivePage.ts
+++ b/interactivePage.ts
@@ -107,7 +107,7 @@ const stackViewGutter = gutter({
         for(let i = 0;i<environment.stackMetaItems.length;i++){
           const sm = environment.stackMetaItems[i]
 
-          if(sm?.end===undefined){
+          if(sm && sm.end===undefined){
             let end = view.state.doc.lineAt(view.state.doc.length).number
             //plus 1 so we don't draw end-caps.
             environment.stackMetaItems[i].end = end+1

--- a/pinch/compiler.ts
+++ b/pinch/compiler.ts
@@ -3,7 +3,7 @@ import { Environment } from "./environment";
 import { NodeType, treeNode, RuntimeNode, RuntimeElementType, CreateElementNode,CreateGroupNode, CreateNumberNode,CreateStringNode,RuntimeType } from "./ast";
 import paper from "paper";
 import { PEvalError } from "./pinchError";
-import { Point } from "paper/dist/paper-core";
+
 
 function compileAndRun(canvas: HTMLCanvasElement, root: treeNode): Environment{
 

--- a/pinch/compiler.ts
+++ b/pinch/compiler.ts
@@ -112,7 +112,7 @@ function compile(node:treeNode, env: Environment): RuntimeNode{
             }
             //else
             compile(node.children[0], env)
-            env.push(env.active); 
+            env.push(env.active,node); 
             break;
         case NodeType.Pop:
             c = env.peek(node);
@@ -132,14 +132,14 @@ function compile(node:treeNode, env: Environment): RuntimeNode{
             if(node.children.length == 1){
                 //pop the number of dots.
                 for(let pops = 0;pops<node.children[0];pops++){
-                    env.pop();
+                    env.pop(node);
                 }
             }else if(node.children.length == 2){
 
                 let poppedChilds = []
                 //pop the number of dots and shove em into a list for us to use...
                 for(let pops = 0;pops<node.children[0];pops++){
-                    poppedChilds.push(env.pop());
+                    poppedChilds.push(env.pop(node));
                 }
                 compilePopStatement(node.children[1],poppedChilds,env);
             }else{
@@ -593,14 +593,12 @@ function compilePopStatement(node: treeNode ,args: RuntimeNode[], env: Environme
 }
 
 function compileEnvironmentProperty(node: treeNode, env: Environment){
-    console.log(node)
     switch(node.id){
         case "width":
             checkChildrenLengthForArgument(node,1);
             let w = compile(node.children[0],env).getNumberValue()
             env.width = w;
             paper.view.viewSize.width = w;
-            console.log("set width to ",w)
             break
         case "height":
             checkChildrenLengthForArgument(node,1);

--- a/pinch/compiler.ts
+++ b/pinch/compiler.ts
@@ -308,7 +308,7 @@ function compileFlowStatement(node: treeNode, env: Environment){
             body.forEach(s=>{
                 compile(s,env)
             })
-            env.pop();
+            env.pop(node);
         break;
         default:
             throw new PEvalError("UnknownID","Unknown control flow statement "+node.id, node)

--- a/pinch/environment.ts
+++ b/pinch/environment.ts
@@ -7,8 +7,10 @@ class StackMetaItem {
 }
 
 class Environment  {
-    width: number = 256
-    height: number = 256
+    //todo: currently a bug where the width and height need to match what the canvas defaults. Currently set in css.
+    //
+    width: number = 200
+    height: number = 200
     active: RuntimeNode | null = null
     root: RuntimeNode
     stack: RuntimeNode[] = []
@@ -45,14 +47,17 @@ class Environment  {
         this.stackMetaIndices.push(x-1)
     }
     pop(node:treeNode):RuntimeNode{
+        if(this.stack.length == 1){
+            throw new PEvalError("EmptyStack","Nothing to pop!",node)
+        }
         let x= this.stack.pop();
         let lineNum = node.sourceInterval.getLineAndColumn().lineNum
         //dumb gutter calculation things
         let index = this.stackMetaIndices.pop();
-        if(index){
+        if(index != undefined){
             let top = this.stackMetaItems[index]
             if(top){
-                this.stackMetaItems[index].end = lineNum
+                top.end = lineNum
             }
         }
 
@@ -62,7 +67,6 @@ class Environment  {
         }else{
             //console.log("popped empty stack!",this.stack)
             throw new PEvalError("EmptyStack","Empty Stack!",node)
-            return this.root
         }
     }
     peek(node:treeNode):RuntimeNode{


### PR DESCRIPTION
it's hacky and does a loop for every line, so it's O(#lines x #stackpushes) ... and it could be cached better...

i don't like it, but i don't know about codemirror well enough to do better for now.

Future updates will need to tint colors for different types of contexts, and then have tooltips.